### PR TITLE
Handle finish events on transactions returned from cache

### DIFF
--- a/t/mojo_useragent_cached.t
+++ b/t/mojo_useragent_cached.t
@@ -224,16 +224,13 @@ subtest 'Should emit events even if content is cached' => sub {
     $tx->req->on(finish => sub { $finished_req++ });
     $tx->on(finish => sub { $finished_tx++ });
     $tx->res->on(finish => sub { $finished_res++ });
-    $ua->start($tx);
-    is $finished_tx,  1, 'finish event has been emitted once';
-    TODO: {
-      local $TODO = 'Events partially implemented';
-      is $finished_req, 1, 'finish event has been emitted once';
-      is $finished_res, 1, 'finish event has been emitted once';
-      ok $tx->req->is_finished, 'request is finished';
-      ok $tx->is_finished, 'transaction is finished';
-      ok $tx->res->is_finished, 'response is finished';
-    }
+    my $cached_tx = $ua->start($tx);
+    is $finished_tx,  1, 'finish event on transaction has been emitted once';
+    is $finished_req, 1, 'finish event on request has been emitted once';
+    is $finished_res, 1, 'finish event on response has been emitted once';
+    ok $cached_tx->is_finished, 'transaction is finished';
+    ok $cached_tx->req->is_finished, 'request is finished';
+    ok $cached_tx->res->is_finished, 'response is finished';
 };
 
 subtest 'expired+cached functionality' => sub {


### PR DESCRIPTION
`Mojo::Transaction` has a [`finish` event](https://docs.mojolicious.org/Mojo/Transaction#finish) which can be subscribed to to trigger a callback when the transaction completes.  Because `Mojo::UserAgent::Cached` creates a new transaction containing the cached response, such a callback is only called when content is fetched, not when returned from cache.

This commit fixes it so that the `finish` callback is called even for transactions returning cached responses.

This seems to be sufficient for my use case (which is [Mojo::UserAgent::Role::Queued](https://metacpan.org/pod/Mojo::UserAgent::Role::Queued)).  More work would be required to support other events, such as the `finish` events on `req` and `res`.