### PR TITLE
Provide a definition for _url()

### DIFF
--- a/lib/Mojo/UserAgent/Cached.pm
+++ b/lib/Mojo/UserAgent/Cached.pm
@@ -493,6 +493,8 @@ sub _get_stacktrace {
     } grep { $_ } @frames;
 }
 
+sub _url { shift->req->url->to_abs }
+
 1;
 
 =encoding utf8


### PR DESCRIPTION
Fixes the following error when `MOJO_CLIENT_DEBUG=1`:

```
Undefined subroutine &Mojo::UserAgent::Cached::_url called at …/lib/perl5/Mojo/UserAgent/Cached.pm line 195.
```